### PR TITLE
Implement brand/category/admin controllers and add model validations

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,0 +1,49 @@
+class Admin::ProductsController < ApplicationController
+  before_action :set_product, only: %i[show edit update destroy]
+
+  def index
+    @products = Product.all
+  end
+
+  def show
+  end
+
+  def new
+    @product = Product.new
+  end
+
+  def create
+    @product = Product.new(product_params)
+    if @product.save
+      redirect_to [:admin, @product], notice: 'Товар создан.'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @product.update(product_params)
+      redirect_to [:admin, @product], notice: 'Товар обновлен.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @product.destroy
+    redirect_to admin_products_path, notice: 'Товар удален.'
+  end
+
+  private
+
+  def set_product
+    @product = Product.find(params[:id])
+  end
+
+  def product_params
+    params.require(:product).permit(:name, :sku, :price, :description, :brand_id, :category_id, :image)
+  end
+end

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,0 +1,49 @@
+class BrandsController < ApplicationController
+  before_action :set_brand, only: %i[show edit update destroy]
+
+  def index
+    @brands = Brand.all
+  end
+
+  def show
+  end
+
+  def new
+    @brand = Brand.new
+  end
+
+  def create
+    @brand = Brand.new(brand_params)
+    if @brand.save
+      redirect_to @brand, notice: 'Бренд создан.'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @brand.update(brand_params)
+      redirect_to @brand, notice: 'Бренд обновлен.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @brand.destroy
+    redirect_to brands_path, notice: 'Бренд удален.'
+  end
+
+  private
+
+  def set_brand
+    @brand = Brand.find(params[:id])
+  end
+
+  def brand_params
+    params.require(:brand).permit(:name)
+  end
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,49 @@
+class CategoriesController < ApplicationController
+  before_action :set_category, only: %i[show edit update destroy]
+
+  def index
+    @categories = Category.all
+  end
+
+  def show
+  end
+
+  def new
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.new(category_params)
+    if @category.save
+      redirect_to @category, notice: 'Категория создана.'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @category.update(category_params)
+      redirect_to @category, notice: 'Категория обновлена.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @category.destroy
+    redirect_to categories_path, notice: 'Категория удалена.'
+  end
+
+  private
+
+  def set_category
+    @category = Category.find(params[:id])
+  end
+
+  def category_params
+    params.require(:category).permit(:name)
+  end
+end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,4 +1,6 @@
 class Brand < ApplicationRecord
   has_many :products
   has_one_attached :logo
+
+  validates :name, presence: true
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,3 +1,5 @@
 class CartItem < ApplicationRecord
   belongs_to :product
+
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,5 @@
 class Category < ApplicationRecord
   has_many :products
+
+  validates :name, presence: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,4 +2,7 @@ class Product < ApplicationRecord
   belongs_to :brand
   belongs_to :category
   has_one_attached :image
+
+  validates :name, presence: true
+  validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: [:admin, product]) do |form| %>
+  <% if product.errors.any? %>
+    <div>
+      <h2><%= pluralize(product.errors.count, 'error') %> prohibited this product from being saved:</h2>
+      <ul>
+        <% product.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+  <div>
+    <%= form.label :price %>
+    <%= form.number_field :price, step: 0.01 %>
+  </div>
+  <div>
+    <%= form.label :brand %>
+    <%= form.collection_select :brand_id, Brand.all, :id, :name %>
+  </div>
+  <div>
+    <%= form.label :category %>
+    <%= form.collection_select :category_id, Category.all, :id, :name %>
+  </div>
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Product</h1>
+<%= render 'form', product: @product %>
+<%= link_to 'Back', admin_products_path %>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,0 +1,20 @@
+<h1>Admin Products</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @products.each do |product| %>
+      <tr>
+        <td><%= product.name %></td>
+        <td><%= link_to 'Show', [:admin, product] %></td>
+        <td><%= link_to 'Edit', edit_admin_product_path(product) %></td>
+        <td><%= link_to 'Destroy', [:admin, product], method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= link_to 'New Product', new_admin_product_path %>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New Product</h1>
+<%= render 'form', product: @product %>
+<%= link_to 'Back', admin_products_path %>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -1,0 +1,10 @@
+<p>
+  <strong>Name:</strong>
+  <%= @product.name %>
+</p>
+<p>
+  <strong>Price:</strong>
+  <%= number_to_currency(@product.price) %>
+</p>
+<%= link_to 'Edit', edit_admin_product_path(@product) %> |
+<%= link_to 'Back', admin_products_path %>

--- a/app/views/brands/_form.html.erb
+++ b/app/views/brands/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with(model: brand) do |form| %>
+  <% if brand.errors.any? %>
+    <div>
+      <h2><%= pluralize(brand.errors.count, 'error') %> prohibited this brand from being saved:</h2>
+      <ul>
+        <% brand.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/brands/edit.html.erb
+++ b/app/views/brands/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Brand</h1>
+<%= render 'form', brand: @brand %>
+<%= link_to 'Back', brands_path %>

--- a/app/views/brands/index.html.erb
+++ b/app/views/brands/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Brands</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @brands.each do |brand| %>
+      <tr>
+        <td><%= link_to brand.name, brand %></td>
+        <td><%= link_to 'Edit', edit_brand_path(brand) %></td>
+        <td><%= link_to 'Destroy', brand, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= link_to 'New Brand', new_brand_path %>

--- a/app/views/brands/new.html.erb
+++ b/app/views/brands/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New Brand</h1>
+<%= render 'form', brand: @brand %>
+<%= link_to 'Back', brands_path %>

--- a/app/views/brands/show.html.erb
+++ b/app/views/brands/show.html.erb
@@ -1,0 +1,6 @@
+<p>
+  <strong>Name:</strong>
+  <%= @brand.name %>
+</p>
+<%= link_to 'Edit', edit_brand_path(@brand) %> |
+<%= link_to 'Back', brands_path %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with(model: category) do |form| %>
+  <% if category.errors.any? %>
+    <div>
+      <h2><%= pluralize(category.errors.count, 'error') %> prohibited this category from being saved:</h2>
+      <ul>
+        <% category.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Category</h1>
+<%= render 'form', category: @category %>
+<%= link_to 'Back', categories_path %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Categories</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @categories.each do |category| %>
+      <tr>
+        <td><%= link_to category.name, category %></td>
+        <td><%= link_to 'Edit', edit_category_path(category) %></td>
+        <td><%= link_to 'Destroy', category, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= link_to 'New Category', new_category_path %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New Category</h1>
+<%= render 'form', category: @category %>
+<%= link_to 'Back', categories_path %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,6 @@
+<p>
+  <strong>Name:</strong>
+  <%= @category.name %>
+</p>
+<%= link_to 'Edit', edit_category_path(@category) %> |
+<%= link_to 'Back', categories_path %>


### PR DESCRIPTION
## Summary
- flesh out missing brand, category, and admin product routes with controllers and views
- ensure basic presence validations for models

## Testing
- `bin/rails test` *(fails: rbenv: version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c185437d08326b0d9b8cab7397df6