### PR TITLE
Add seed data and tweak navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,11 +15,13 @@
   <body class="bg-gray-100 font-sans">
     <header class="bg-black text-white">
       <div class="container mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="text-xl font-bold">PartParty</div>
+        <div class="text-xl font-bold">
+          <%= link_to 'PartParty', root_path, class: 'hover:text-red-500' %>
+        </div>
         <nav class="flex items-center gap-6" x-data="{ open: null }">
           <div @mouseenter="open = 'atv'" @mouseleave="open = null" class="relative">
-            <button class="hover:text-red-500">ATV/UTV</button>
-            <div x-show="open === 'atv'" class="absolute left-0 mt-2 w-64 bg-white text-black shadow-lg rounded z-50">
+            <button @click="open = (open === 'atv') ? null : 'atv'" class="hover:text-red-500">ATV/UTV</button>
+            <div x-show="open === 'atv'" @click.away="open = null" class="absolute left-0 mt-2 w-64 bg-white text-black shadow-lg rounded z-50">
               <ul class="p-4 space-y-2">
                 <li><a href="#" class="hover:text-red-600 block">Tires & Wheels</a></li>
                 <li><a href="#" class="hover:text-red-600 block">Body</a></li>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,60 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Seed basic reference data for local development and test environments.
+# These records are created idempotently so the seed can be safely
+# executed multiple times.
+
+brands = %w[Polaris Yamaha Honda].map do |name|
+  Brand.find_or_create_by!(name: name)
+end
+
+categories = %w[Engine Suspension Accessories].map do |name|
+  Category.find_or_create_by!(name: name)
+end
+
+products_data = [
+  {
+    name: 'Polaris RZR Belt',
+    sku: 'PRZR-BELT',
+    price: 49.99,
+    brand: brands[0],
+    category: categories[0],
+    description: 'High quality drive belt for Polaris RZR.'
+  },
+  {
+    name: 'Yamaha Oil Filter',
+    sku: 'YAM-OF',
+    price: 12.95,
+    brand: brands[1],
+    category: categories[0],
+    description: 'Genuine Yamaha oil filter.'
+  },
+  {
+    name: 'Honda Cargo Rack',
+    sku: 'HON-RACK',
+    price: 85.50,
+    brand: brands[2],
+    category: categories[2],
+    description: 'Durable rear cargo rack.'
+  },
+  {
+    name: 'Universal Shock Absorber',
+    sku: 'UNI-SHOCK',
+    price: 120.0,
+    brand: brands[1],
+    category: categories[1],
+    description: 'Adjustable suspension component.'
+  },
+  {
+    name: 'ATV Helmet',
+    sku: 'ATV-HELM',
+    price: 60.75,
+    brand: brands[0],
+    category: categories[2],
+    description: 'Protective helmet for off‑road riding.'
+  }
+]
+
+products_data.each do |attrs|
+  Product.find_or_create_by!(name: attrs[:name]) do |product|
+    product.assign_attributes(attrs)
+  end
+end


### PR DESCRIPTION
## Summary
- add initial seed data for brands, categories and products
- make header logo a link to home
- improve dropdown behavior with click toggle and click-away

## Testing
- `bundle install` *(fails: ruby 3.3.7 not installed)*
- `bundle exec rake test` *(fails: ruby 3.3.7 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e9e6f688326ac8853329403e3c9