### PR TITLE
Add seed data and update navbar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
   <body class="bg-gray-100 font-sans">
     <header class="bg-black text-white">
       <div class="container mx-auto px-4 py-3 flex items-center justify-between">
-        <div class="text-xl font-bold">PartParty</div>
+        <div class="text-xl font-bold">
+          <%= link_to "PartParty", root_path, class: "hover:text-red-400" %>
+        </div>
         <nav class="flex items-center gap-6" x-data="{ open: null }">
           <div @mouseenter="open = 'atv'" @mouseleave="open = null" class="relative">
             <button class="hover:text-red-500">ATV/UTV</button>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,28 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+
+# Basic seed data for local testing
+
+yamaha = Brand.find_or_create_by!(name: "Yamaha")
+honda  = Brand.find_or_create_by!(name: "Honda")
+
+engines     = Category.find_or_create_by!(name: "Engine")
+suspension  = Category.find_or_create_by!(name: "Suspension")
+
+Product.find_or_create_by!(name: "Shock Absorber") do |p|
+  p.sku = "SH-001"
+  p.price = 199.99
+  p.description = "Demo product for testing"
+  p.brand = yamaha
+  p.category = suspension
+end
+
+Product.find_or_create_by!(name: "Oil Filter") do |p|
+  p.sku = "OF-100"
+  p.price = 29.99
+  p.description = "Demo product for testing"
+  p.brand = honda
+  p.category = engines
+end
+


### PR DESCRIPTION
## Summary
- seed the database with sample brands, categories and products for testing
- link the navbar site name to the home page

## Testing
- `bin/rails test` *(fails: rbenv: version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c320182488326b58628b160631571