### PR TITLE
Integrate Builder.io

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,6 @@
+class PagesController < ApplicationController
+  # Render Builder.io pages by path.
+  def show
+    # The view handles loading Builder content.
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 // import "controllers";
 // import "@hotwired/turbo-rails"
 import Alpine from "alpinejs"
+import "builder-webcomponents"
 
 window.Alpine = Alpine
 Alpine.start()

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,12 +4,14 @@
     <title>PartParty</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
+    <meta name="builder-api-key" content="<%= ENV['BUILDER_API_KEY'] %>">
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.builder.io/js/webcomponents"></script>
   </head>
 
   <body class="bg-gray-100 font-sans">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,1 @@
+<builder-component model="page" api-key="<%= ENV['BUILDER_API_KEY'] %>" data-path="/<%= params[:path] %>"></builder-component>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,3 +3,4 @@
 pin "application", to: "application.js", preload: true
 pin "@hotwired/turbo-rails"
 pin "alpinejs", to: "https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/module.esm.js"
+pin "builder-webcomponents", to: "https://cdn.builder.io/js/webcomponents"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   resources :products
   resources :cart_items, only: [:index, :create, :update, :destroy]
 
+  get 'pages/*path', to: 'pages#show', as: :builder_page
+
   namespace :admin do
     resources :products
   end


### PR DESCRIPTION
## Summary
- add Builder.io page controller and view
- include Builder.io CDN script in the layout
- load Builder library via importmap and application.js
- route pages/* to Builder.io content

## Testing
- `bin/rails --version` *(fails: version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c40103ee08326886626cf07a62b32